### PR TITLE
docs: correct reference sources and add per-repo strengths

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Landing context
-    url: ./../landing-context.md
+    url: https://github.com/IrrealV/gentle-ai-community-landing/blob/main/landing-context.md
     about: Read the current synthesis before opening a change.
+  - name: Landing strengths
+    url: https://github.com/IrrealV/gentle-ai-community-landing/blob/main/landing-strengths.md
+    about: Per-repo strong points and ideas worth reusing.

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-repo-yo/
 repo-fabri/
 repo-gerardo/
+repo-irrealv/
+repo-becker/

--- a/README.md
+++ b/README.md
@@ -4,17 +4,20 @@ Community landing repo for **GENTLE-AI**.
 
 ## Goal
 
-Build one shared landing page by combining the best ideas from the available references:
+Build one shared landing page by combining the best ideas from four independent Astro landings:
 
-- `repo-yo/`
-- `repo-fabri/`
-- `repo-gerardo/`
-- Becker public landing: https://gentleai.vercel.app/
+| Author   | Repository                                                          |
+|----------|---------------------------------------------------------------------|
+| Fabri    | https://github.com/fabriortenzi/gentle-ai-landing                   |
+| Gerardo  | https://github.com/GerardoFC8/landing-gentle-ai                     |
+| IrrealV  | https://github.com/IrrealV/gentle-landing                           |
+| Becker   | https://github.com/niko05becker/gentleai-landing — live at https://gentleai.vercel.app/ |
 
 ## Current status
 
-- `landing-context.md` contains the synthesis of the imported references.
-- The cloned repos are kept here only as context snapshots.
+- `landing-context.md` — synthesis and merge strategy for the community landing.
+- `landing-strengths.md` — per-repo breakdown of strong points, weaknesses, and ideas to reuse.
+- Reference repos are consumed as **remote links**, not committed snapshots. Contributors may clone them locally into sibling folders (`repo-fabri/`, `repo-gerardo/`, `repo-irrealv/`, `repo-becker/`) which are gitignored.
 - Community governance files are being added now.
 
 ## Community rules
@@ -34,11 +37,12 @@ Build one shared landing page by combining the best ideas from the available ref
 
 ## Start here
 
-1. Read `landing-context.md`
-2. Read `CONTRIBUTING.md`
-3. Open an issue for the change
-4. Work in a branch named `type/description`
-5. Open a PR using the template
+1. Read `landing-context.md` for the merge strategy.
+2. Read `landing-strengths.md` for per-repo evidence.
+3. Read `CONTRIBUTING.md`.
+4. Open an issue for the change.
+5. Work in a branch named `type/description`.
+6. Open a PR using the template.
 
 ## Notes
 

--- a/landing-context.md
+++ b/landing-context.md
@@ -1,170 +1,130 @@
 # Gentle-AI landing context
 
-This document collects the best ideas from the available landing pages so we can build a single community-owned version with the strongest parts of each one.
+This document is the synthesis that drives the community landing. It describes the reference sources, what each one does well, and the merged direction we'll build from.
 
-## Sources imported into this folder
+## Goal
 
-- `repo-yo/` — cloned from `https://github.com/IrrealV/gentle-landing`
-- `repo-fabri/` — cloned from `https://github.com/IrrealV/gentle-landing`
-- `repo-gerardo/` — cloned from `https://github.com/IrrealV/gentle-landing`
-- Becker landing — public site at `https://gentleai.vercel.app/`
+Build a single community-owned landing for **GENTLE-AI** by combining the strongest parts of four existing landings, instead of forking any single one of them.
 
-## Important note about the three GitHub repos
+## Reference sources
 
-The three GitHub sources are the same repository snapshot, not three different codebases. They all resolved to the same commit (`b822ece4e0bef48c66de895677d128222acd27a4`). So the real comparison is:
+Four independent Astro landings, each built by a different contributor. The live site column only reflects confirmed public deployments at the time of writing.
 
-- the shared Astro implementation in the repo clones
-- the public Becker landing as a separate reference
+| Author   | Repository                                                          | Live site                      |
+|----------|---------------------------------------------------------------------|--------------------------------|
+| Fabri    | https://github.com/fabriortenzi/gentle-ai-landing                   | —                              |
+| Gerardo  | https://github.com/GerardoFC8/landing-gentle-ai                     | —                              |
+| IrrealV  | https://github.com/IrrealV/gentle-landing                           | —                              |
+| Becker   | https://github.com/niko05becker/gentleai-landing                    | https://gentleai.vercel.app/   |
 
-That is still useful: the cloned repo gives us the actual implementation decisions, and Becker gives us an external design/copy alternative.
+### Local clones
+
+For local inspection contributors may clone each repo into sibling folders:
+
+- `repo-fabri/`
+- `repo-gerardo/`
+- `repo-irrealv/`
+- `repo-becker/`
+
+These folders are listed in `.gitignore` and **must not be committed**. The canonical source of each landing is the GitHub repository above, not the local clone.
+
+## Quick comparison
+
+| Aspect                       | Fabri                          | Gerardo                              | IrrealV                                  | Becker                                |
+|------------------------------|--------------------------------|--------------------------------------|------------------------------------------|---------------------------------------|
+| Framework                    | Astro 6, vanilla               | Astro 5 + React islands              | Astro 6, vanilla                         | Astro 5, vanilla                      |
+| Tailwind                     | 4 (vite plugin)                | 4 (vite plugin)                      | 4 (vite plugin)                          | 3 (classic integration)               |
+| Pages                        | Single scroll                  | Single scroll (+ `/es/`)             | Multi-page (`/`, `/features`, `/how-it-works`, `/docs`, `/demo`) | Single scroll                         |
+| i18n                         | None                           | Route-split EN/ES                    | DOM-swap EN/ES                           | None                                  |
+| Live GitHub stats            | Hardcoded                      | Server-side at build                 | Client-side with sessionStorage cache    | Hardcoded                             |
+| Interactive demo             | —                              | React island (xterm)                 | Dedicated `/demo` page                   | —                                     |
+| Hero signature               | Cycling typed-terminal         | Two-column + xterm island            | Two-column + install tabs + OS auto-detect | macOS-window install widget + presets |
+| Deployed & inspectable live  | Not confirmed                  | Not confirmed                        | Not confirmed                            | Yes                                   |
 
 ## What each source does well
 
-### 1) Shared GitHub landing (`repo-yo`, `repo-fabri`, `repo-gerardo`)
+A detailed per-landing breakdown lives in [`landing-strengths.md`](./landing-strengths.md). The short version:
 
-#### Strong points
+- **Fabri** — cleanest typography (Iosevka), a looping typed-terminal hero, and the most disciplined `prefers-reduced-motion` handling.
+- **Gerardo** — the richest narrative (Problem → Solution → pillars → ecosystem → build-your-own), route-split EN/ES i18n, server-side GitHub stats, JSON-LD SEO.
+- **IrrealV** — the only true multi-page site with a real docs manual and a keyboard-driven demo; OS auto-detection and full ARIA-compliant install tabs.
+- **Becker** — the only landing actually deployed, with the strongest brand polish: macOS-window install widget, build-time OG images, complete meta/OG/Twitter/favicon kit, and a "Presets" section that frames buyer intent.
 
-- Very clear product framing: **“One command. Any agent. Any OS.”**
-- Strong install-first hero with OS-specific tabs (`brew`, `go install`, `scoop`)
-- Good proof of substance:
-  - GitHub stars / forks / release badge
-  - explicit supported agents
-  - explicit component catalog
-- Nice conversion path:
-  - install
-  - docs
-  - demo
-- The docs page is unusually strong for a landing:
-  - explains the system like a manual
-  - includes install commands
-  - maps SDD phases to artifacts
-  - shows the ecosystem as a matrix, not just marketing copy
-- The demo page is honest and useful:
-  - says it is a browser reconstruction, not the native runtime
-  - gives keyboard help
-  - includes a mobile warning instead of pretending mobile is ideal
-- Spanish/English copy is already in the implementation, which is good for a community project.
+## Merge strategy for the community landing
 
-#### Weak points
+### Hero
 
-- The landing is a bit **too product-manual-ish** in places; it reads strong technically, but not always emotionally memorable.
-- Some sections are dense and can feel like documentation before persuasion.
-- The home page tries to do a lot at once:
-  - install
-  - feature overview
-  - onboarding
-  - process explanation
-  - stats
-  That is useful, but can dilute the main message.
-- Because all three clones are identical, there is no internal diversity to mine; we need to synthesize rather than compare variants.
+- Keep the official headline: **"One command. Any agent. Any OS."** (tri-line, gradient on the last phrase).
+- Use Becker's **macOS-window install widget** as the primary visual.
+- Inside that widget, use IrrealV's **OS auto-detection**, keyboard-navigable tabs (ARIA `role="tablist"`), and copy buttons.
+- Frame the widget with Gerardo's **two-column asymmetric layout**: left = pitch + version badge + CTAs, right = widget.
+- Fetch the version badge **server-side at build time** (Gerardo's `lib/github.ts` pattern) and link it to the specific release, Becker-style.
+- Fabri's looping-typing terminal is beautiful but redundant with an install widget — reserve it for a secondary "watch it cycle" surface or drop it.
 
-#### Best ideas to keep
+### Site structure
 
-- OS-specific install tabs in the hero
-- Copy buttons for commands
-- Clear GitHub proof points
-- Demo as a browser reconstruction with honesty labels
-- Multi-language labels
-- A docs page that behaves like a real product manual
+Adopt IrrealV's **multi-page model**:
 
----
+- `/` — marketing home
+- `/features`
+- `/how-it-works`
+- `/docs` — real manual, sidebar + prev/next navigation
+- `/demo` — keyboard-driven Bubbletea reconstruction, honest about being a browser reconstruction
 
-### 2) Becker public landing (`gentleai.vercel.app`)
+On `/`, follow Gerardo's narrative arc and insert Becker's **Presets** section before install:
 
-#### Strong points
+1. Hero (install-first)
+2. Problem
+3. Solution with pillars (Engram / SDD / Skills / Persona)
+4. How it works
+5. Agents grid (data-driven)
+6. Build-your-own-agent
+7. Presets (Full Gentleman / Ecosystem Only / Minimal / Custom)
+8. Install
+9. Community / Final CTA
+10. Footer
 
-- Much cleaner, more direct hero copy:
-  - **“One command. Any agent. Any OS.”**
-  - very fast to understand
-- Strong punchy positioning for the ecosystem/configurator angle
-- Good marketing rhythm:
-  - install
-  - what it does
-  - agents
-  - components
-  - install
-  That cadence is easy to scan.
-- The page balances marketing and product detail without drowning in documentation.
-- It keeps the brand language sharp and concise.
+### Aesthetic
 
-#### Weak points
+- Becker's polish as the baseline: full meta/OG/Twitter/manifest/favicon kit, Satori-based **build-time OG image generation**, custom-cursor + parallax radial glow.
+- Gerardo's tri-token color system (`primary / secondary / tertiary`) with gradient accents.
+- Fabri's `prefers-reduced-motion` discipline baked in from day one.
+- Terminal/engineering vibe carried across all surfaces — no generic SaaS visuals.
 
-- It is less complete as a technical reference than the GitHub repo landing.
-- Less of the “why this is serious” depth than the docs-heavy version.
-- Without the repo, we cannot inspect implementation decisions or code structure.
+### i18n
 
-#### Best ideas to keep
+- Gerardo's **route-split** approach (`/` + `/es/`) wins over DOM-swap on SEO.
+- Reuse the existing `src/i18n/{en,es}.ts` contract as the starting point.
 
-- The top-line positioning
-- The short, memorable language
-- The visual hierarchy that lets the value proposition land immediately
-- The less-bloated marketing tone
+### Data layer
 
----
+- One source of truth per domain, following Gerardo's pattern:
+  - `src/data/agents.ts` — agent list with logos and descriptions
+  - `src/data/presets.ts` — Becker's presets as editable data
+  - `src/lib/github.ts` — build-time GitHub fetch (stars, forks, release, contributors)
 
-## Best parts to merge into the community landing
+### Content rules
 
-### Messaging
+- Factual, not hypey.
+- Explain the ecosystem in one sentence first.
+- Separate marketing copy (`/`) from manual copy (`/docs`).
+- Bilingual EN/ES is a first-class requirement, not an afterthought.
+- The demo page is honest about being a browser reconstruction.
 
-Use Becker’s compact hero language, but back it with the technical credibility of the GitHub landing.
+## Community project direction (secondary track)
 
-Recommended direction:
+Governance layer for this repo:
 
-- headline: short and memorable
-- subheadline: one sentence explaining what Gentle-AI actually is
-- supporting line: memory + SDD + skills + persona + routing
-- CTA set: install / docs / demo
-
-### Structure
-
-1. Hero with install-first CTA
-2. Trust/proof section
-3. Clear “what it does” section
-4. “How it works” / SDD pipeline
-5. Docs/manual section
-6. Demo section
-7. Community/contribution section
-
-### Visual decisions
-
-- Keep the terminal/engineering aesthetic from the GitHub landing
-- Keep Becker’s restraint and clarity
-- Avoid overloading the first screen with too many concepts
-- Use progressive disclosure: the landing should invite deeper reading, not dump everything at once
-
-### Content decisions
-
-- Be factual, not hypey
-- Explain the ecosystem in a single sentence first
-- Separate marketing copy from technical manual copy
-- Keep English + Spanish support from the repo
-- Make the demo feel like a product, not a toy
-
-## Community project direction (secondary task)
-
-Not implemented yet, but this is the right shape for a community repo:
-
-- protect `main`
-- require PRs for changes
-- add contribution guidelines
-- add PR review rules
-- add a clear code/style standard
-- define ownership for copy, design, and technical changes
-- keep repo snapshots and imported references documented
-
-## Recommendation
-
-The best landing is **not** any single one of these.
-
-It should combine:
-
-- Becker’s short, confident hook
-- the GitHub landing’s technical credibility
-- the docs/manual depth
-- the honest interactive demo framing
-
-In practice: **simple hero, serious proof, clear workflow, strong docs, honest demo**.
+- Protect `main`.
+- Require PRs for every change.
+- Add contribution guidelines.
+- Add PR review rules.
+- Define ownership for copy, design, and technical changes.
+- Keep the reference repos as **remote links**, not as committed snapshots.
 
 ## Next step
 
-Build the community landing from this synthesis and then add the community governance layer as a secondary pass.
+1. Scaffold the community landing from this synthesis (Astro + Tailwind 4 + route-split i18n).
+2. Port the merged hero, presets section, and install widget first.
+3. Add `/docs` and `/demo` pages in a second pass.
+4. Layer the governance automation on top once the page is live.

--- a/landing-strengths.md
+++ b/landing-strengths.md
@@ -1,0 +1,248 @@
+# Landing strengths
+
+This document captures the strong points, weak points, and "best ideas to steal" for each of the four reference landings. It is the detailed companion to [`landing-context.md`](./landing-context.md).
+
+The goal is not to pick a winner — it is to name, per repo, the decisions that are good enough to survive into the community landing.
+
+---
+
+## 1. Fabri — `fabriortenzi/gentle-ai-landing`
+
+- Repository: https://github.com/fabriortenzi/gentle-ai-landing
+
+### Tech stack
+
+- Astro 6, Tailwind CSS 4 via `@tailwindcss/vite`, `@astrojs/sitemap`
+- Pure `.astro`, no React islands, no TypeScript components
+- Self-hosted Iosevka mono font
+- Node engine `>=22.12`
+
+### Hero
+
+- Eyebrow `AI Gentle Stack` (fuchsia mono)
+- Headline `One command. Any agent. Any OS.` — gradient animation on the middle phrase
+- Subhead: "The Gentleman AI ecosystem — configured and ready."
+- **No install tabs in the hero**. Instead, a single animated terminal types and erases five install commands (curl, brew, scoop, go install, PowerShell) with `prefers-reduced-motion` respected.
+- CTAs: `Star on GitHub` + `See Features ↓`
+
+### Section order
+
+Navbar → Hero → BeforeAfter → HowItWorks → AgentGrid → EngramSection → SDDSection → SkillsSection → InstallSection → Community
+
+### Standout features
+
+- Cleanest and most opinionated typography system of the four.
+- The cycling-terminal hero is the most recognizable signature.
+- Install tabs moved to a dedicated `InstallSection` with **five** methods, not three.
+- `prefers-reduced-motion` handling is explicit and consistent.
+
+### Weaknesses
+
+- No docs page, no demo page.
+- No bilingual support.
+- GitHub stats are hardcoded.
+- README is minimal.
+- Smallest scope of the four.
+
+### Best ideas to steal
+
+1. Looping typed-terminal as a hero signature.
+2. Install matrix with five methods in its own section.
+3. `prefers-reduced-motion` discipline across all animations.
+4. Iosevka (or equivalent) mono font ownership.
+
+---
+
+## 2. Gerardo — `GerardoFC8/landing-gentle-ai`
+
+- Repository: https://github.com/GerardoFC8/landing-gentle-ai
+
+### Tech stack
+
+- Astro 5 + React 19 islands (`@astrojs/react`)
+- Tailwind 4 (vite plugin), `motion`, `xterm` (real terminal embed), `@lucide/astro`, `@vercel/analytics`
+- Full i18n wired into `astro.config.mjs` (`en` default, `es` at `/es/`) with `src/i18n/{en,es}.ts` + `utils.ts`
+- JSON-LD `SoftwareApplication` structured data
+- TypeScript-heavy
+
+### Hero
+
+- Asymmetric two-column layout.
+- Left: version badge (live from GitHub releases API, cached), 3-line headline `One command. / Any agent. / Any OS.` with gradient on the last line, i18n subhead, dual CTAs (`Install Now` + `View on GitHub`).
+- Right: a React-island `Terminal` (xterm-based) playing scripted commands.
+- No OS-tab selector in the hero itself.
+
+### Section order
+
+Nav → Hero → Problem → Solution → EngramCallout → HowItWorks → SDDPipeline → Ecosystem → BuildAgent → ModelIntelligence → Demo → Install → Community → FinalCTA → Footer
+
+A mirrored `/es/index.astro` exists for the Spanish route.
+
+### Standout features
+
+- Bilingual EN/ES via Astro native `i18n` config + `/es/` route.
+- Richest narrative arc (Problem → Solution → Pillars → Ecosystem → Build-your-own-agent → Model Intelligence → Demo).
+- Live GitHub stats + latest release + contributors fetched **server-side at build time** via `src/lib/github.ts`.
+- React islands: `ParticleBackground`, `Card3D`, `StatsCounter`, `SDDFlow`, `TUIDemo`, `Terminal`, `ThemeToggle`, `LanguageToggle`.
+- Curated agent data in `src/data/agents.ts` with logos and descriptions.
+- JSON-LD structured data.
+- PRD docs committed in `docs_local/`.
+
+### Weaknesses
+
+- Heaviest bundle of the four (seven islands + xterm).
+- No dedicated `/docs` or `/demo` pages — everything is a single scroll.
+- Complexity tax on anyone editing it.
+
+### Best ideas to steal
+
+1. Route-split EN/ES i18n (`/` and `/es/`).
+2. Server-side GitHub fetch baked at build time (no CORS, no API-key exposure).
+3. Problem → Solution → Pillars narrative (Engram / SDD / Skills / Persona).
+4. JSON-LD `SoftwareApplication` structured data.
+5. `src/data/agents.ts` as the single source of truth for the agent grid.
+
+---
+
+## 3. IrrealV — `IrrealV/gentle-landing`
+
+- Repository: https://github.com/IrrealV/gentle-landing
+
+### Tech stack
+
+- Astro 6, Tailwind 4 (vite plugin), `@tailwindcss/typography`
+- Vanilla Astro, no React
+- Self-hosted Space Grotesk, JetBrains Mono, Material Symbols
+- Node `--test` runner for smoke tests (`tests/**/*.test.mjs`)
+- OpenSpec directory + custom `skills/` system for SDD
+- Package name: `cosmic-chaos`
+
+### Hero
+
+- Two-column layout on `/`.
+- Left: tri-color stacked headline `CONFIGURE / YOUR AI CODING / ECOSYSTEM.` (primary / secondary / tertiary tokens), descriptive subhead calling the project "an ecosystem configurator", **inline live GitHub stats pills** (stars, forks, latest version) fetched client-side with a 15-minute `sessionStorage` cache, and three CTAs (`Workflow Docs`, `GitHub Repository`, `Open TUI Demo`).
+- Right: install-tab widget with **auto-detected OS** (via `navigator.userAgentData.platform`) across brew / go install / scoop. Full keyboard navigation (ArrowRight / ArrowLeft / Home / End) and ARIA `role="tablist"`. Copy button bound to the active panel.
+
+### Section order
+
+Multi-page site:
+
+- `/` — Hero → FeaturesGrid → GetStarted → HowItWorks → Stats
+- `/features`
+- `/how-it-works`
+- `/docs` — manual with eight sections, sidebar navigation, prev/next arrows
+- `/demo` — keyboard-driven Bubbletea reconstruction
+
+Shared `Navbar` uses a `variant` prop (marketing / compact / interactive) per page.
+
+### Standout features
+
+- The only landing with a **true multi-page architecture**.
+- `/docs` behaves like an actual product manual.
+- `/demo` is honest about being a browser reconstruction of a TUI.
+- Bilingual via `data-label-en/es` attributes (DOM swap, no route split).
+- Material Symbols icon font.
+- OpenSpec + SDD artifacts committed (`openspec/`, `skills/`, `.engram/`, `stitch/`, `tests/`).
+- Node test suite for homepage and TUI flows.
+- View Transitions enabled.
+
+### Weaknesses
+
+- Largest repo by far (many non-landing artifacts shipped).
+- Naming / branding drift (`cosmic-chaos`, uppercase `GENTLE-AI`).
+- Bilingual is DOM-swap, which is weaker for SEO than Gerardo's route split.
+- Some aesthetic details feel less polished than Becker.
+
+### Best ideas to steal
+
+1. Multi-page structure: dedicated `/docs`, `/demo`, `/features`, `/how-it-works`.
+2. OS auto-detection for the default install tab (`navigator.userAgentData`).
+3. ARIA `role="tablist"` plus full keyboard navigation on install tabs.
+4. Live GitHub stats with `sessionStorage` cache and graceful fallback.
+5. Interactive TUI demo as a dedicated page, not a hero island.
+6. `node --test` smoke suite for homepage links and sections.
+
+---
+
+## 4. Becker — `niko05becker/gentleai-landing`
+
+- Repository: https://github.com/niko05becker/gentleai-landing
+- Live: https://gentleai.vercel.app/
+
+### Tech stack
+
+- Astro 5 + Tailwind **3** (classic `@astrojs/tailwind` integration)
+- `@lucide/astro`, `lucide-astro`
+- `satori` + `@resvg/resvg-js` + `scripts/generate-og.mjs` for build-time OG images
+- `@fontsource/inter`, `@astrojs/sitemap`
+- All `.astro`, no React
+- Smallest src tree of the four (around twelve components, single page)
+
+### Hero
+
+- Single-column, centered.
+- Animated "Now available" version badge linking to a specific release tag (e.g. `v1.18.3`).
+- Headline with gradient on the first line: `One command.` / `Any agent. Any OS.`
+- Subhead: "The Gentleman AI ecosystem configurator — supercharge any AI coding agent with persistent memory, Spec-Driven Development, curated skills, and a teaching-oriented persona in seconds."
+- **Install widget styled as a macOS window** with traffic-light dots and three tabs (macOS/Linux, Windows, Go install). Copy buttons per panel.
+- Primary CTA: `Get started`. Secondary: `View on GitHub`.
+- Below hero: a **four-stat grid with animated counters** (hardcoded values).
+
+### Section order
+
+Hero → `#what-it-does` (BeforeAfter) → `#agents` → `#components` (Engram, SDD, Skills, Context7, Persona, Permissions, GGA, Theme) → `#skills` (SDD Skills, Foundation Skills, Community Coding Skills) → `#presets` (Full Gentleman / Ecosystem Only / Minimal / Custom) → `#install`
+
+### Standout features
+
+- Strongest brand polish of the four, and the only one **actually deployed** and inspectable live.
+- Build-time OG image generation via Satori (`scripts/generate-og.mjs`).
+- Custom cursor with lerp ring plus parallax radial glow.
+- Full meta / OG / Twitter cards, `theme-color`, manifest, all favicon sizes.
+- "Presets" section (Full Gentleman / Ecosystem Only / Minimal / Custom) is unique to Becker and framing-wise valuable.
+- Clean component-per-section structure, trivially maintainable.
+
+### Weaknesses
+
+- Hardcoded stats that don't reflect the real repo.
+- Tailwind 3 is a version behind.
+- No i18n.
+- No docs or demo pages.
+- No install auto-detection (user has to click).
+- No tests.
+
+### Best ideas to steal
+
+1. macOS-window install widget with traffic-light dots.
+2. Satori-based OG image generation at build time.
+3. "Presets" section (Full Gentleman / Ecosystem Only / Minimal / Custom) as a buyer-funnel tool.
+4. Version-badge linking to the specific release (pulse dot + tag pill + "Now available").
+5. Custom cursor and parallax radial glow as a cheap signature effect.
+6. Complete meta / OG / Twitter / manifest / favicon kit to copy wholesale.
+
+---
+
+## Cross-cutting observations
+
+All four share: Astro framework, Tailwind CSS, the tagline **"One command. Any agent. Any OS."**, a brew/curl/scoop/go-install pitch, a hero terminal or install widget, references to Engram + SDD + Skills, and a CTA pointing to the canonical `Gentleman-Programming/gentle-ai` repository.
+
+Only some have:
+
+- React islands — only Gerardo.
+- Multi-page architecture — only IrrealV.
+- Route-split EN/ES i18n — only Gerardo. IrrealV does DOM-swap. Fabri and Becker are English-only.
+- Live GitHub data — Gerardo (build-time) and IrrealV (client-side with cache).
+- Deployed and live — only Becker (confirmed).
+- Build-time OG images — only Becker.
+- Interactive TUI demo — Gerardo (island) and IrrealV (dedicated page).
+- Automated tests — only IrrealV.
+- OS auto-detection for install — only IrrealV.
+- Explicit `prefers-reduced-motion` handling — only Fabri.
+- Looping typed-terminal hero — only Fabri.
+- Presets section — only Becker.
+- JSON-LD structured data — only Gerardo.
+
+Tailwind version split: Fabri / Gerardo / IrrealV are on v4 with the vite plugin, Becker is still on v3 with the classic integration.
+
+## How this feeds the community landing
+
+The merge strategy and final architecture live in [`landing-context.md`](./landing-context.md). This document is the evidence trail behind each decision — when somebody asks "why are we using the macOS window widget?", this file is the answer.


### PR DESCRIPTION
## Linked issue

Closes #2

## PR type

- [x] Documentation only

## Summary

Corrects the factual errors in `landing-context.md` (three "sources" that were the same repo URL, no folders actually imported) and introduces `landing-strengths.md` as the evidence trail for future decisions. Also updates the supporting files that carried the same misrepresentation.

## Changes

| File | Change |
|------|--------|
| `landing-context.md` | Rewritten with the four real sources, a quick-comparison table, and a concrete merge strategy. |
| `landing-strengths.md` | New — per-repo deep dive (tech, hero, sections, standouts, weaknesses, best ideas). |
| `README.md` | Aligned source list with the four real repos; references the new strengths doc. |
| `.gitignore` | Updated clone folder names to match the four real authors (`repo-fabri/`, `repo-gerardo/`, `repo-irrealv/`, `repo-becker/`). |
| `.github/ISSUE_TEMPLATE/config.yml` | Fixed relative URL to absolute GitHub URL and added a link to the new strengths doc. |

## Test plan

- [x] Verified locally
- [x] Cross-links render correctly on GitHub
- [x] No code changes — docs-only

## Checklist

- [x] Linked an approved issue
- [ ] Added exactly one `type:*` label (pending — labels do not yet exist on this repo; using `documentation` as fallback)
- [x] Kept the change scoped
- [x] Used conventional commit format
- [x] No `Co-Authored-By` trailer

## Reviewer

cc @IrrealV — this PR is the first exercise of the governance flow end-to-end (issue linked, label applied, review required, squash merge) and needs your review as repo owner before merge.
