### PR TITLE
docs: align governance with code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+/.github/ @IrrealV
+* @IrrealV @GerardoFC8 @fabriortenzi @niko05becker
+/.github/CODEOWNERS @IrrealV

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -8,6 +8,7 @@ Recommended settings:
 
 - Require a pull request before merging
 - Require at least 1 review
+- Require code owner reviews when CODEOWNERS is present
 - Dismiss stale reviews when new commits are pushed
 - Require conversation resolution before merge
 - Require status checks to pass

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Build one shared landing page by combining the best ideas from four independent 
 - All changes go through PRs.
 - PRs must link an approved issue.
 - PRs must use exactly one `type:*` label.
+- PRs must get at least one code owner review.
 - Copy should stay factual and consistent with the product.
 
 ## Governance files

--- a/docs/README.md
+++ b/docs/README.md
@@ -182,7 +182,7 @@ Rules:
 
 - Cross-domain PRs need **both** leads to approve.
 - A lead may delegate, but ownership does not transfer without a PR updating this document.
-- No lead may merge their own PR without a second approval.
+- A lead may merge their own PR once the required review rules are satisfied.
 
 ### 4.2 Known risks
 

--- a/feedback_gentleman.md
+++ b/feedback_gentleman.md
@@ -1,0 +1,86 @@
+# 📝 Análisis de Feedback: Landing Pages Gentle-AI
+
+Este documento recopila los puntos positivos y las áreas de mejora comentadas por The Gentleman para cada una de las versiones. El objetivo es extraer "lo mejor de cada una" para la versión final colaborativa.
+
+## 🎨 Becker
+
+**Enfoque:** Estética y claridad estructural.
+
+### ✅ Pros (Lo bueno)
+
+- **Identidad visual:** El "punterito gamer" fue un gran acierto.
+- **Paleta de colores:** Los colores elegidos gustan mucho.
+- **UX de lectura:** Es rápida, concisa y tiene buen ritmo de scroll.
+- **Claridad de conceptos:** La sección donde explica el "Core Stack" y los componentes ayuda mucho a entender qué hace la herramienta.
+- **Empatía con el usuario:** Mencionar los problemas reales de "solo agents" (Windsurf, Cursor, etc.) es un punto muy fuerte.
+- **Social proof:** Mostrar las estrellas y forks de GitHub (aunque recomendó que sean datos vivos vía API).
+
+### ❌ Contras (A mejorar)
+
+- **Branding:** Cambiar el texto "gsic" directamente por el logo oficial.
+- **Coherencia visual:** En la sección de Skills, el texto está escalonado; debería tener un espaciado uniforme para que no se vea desordenado.
+- **Alineación:** Los elementos de las tarjetas deben estar alineados hacia abajo para que los botones mantengan la misma posición siempre.
+- **Contraste:** El texto necesita más contraste (más clarito), ya que actualmente es muy sutil y cuesta leerlo.
+
+## 🚀 Gerardo
+
+**Enfoque:** Marketing de problema/solución y demostración real.
+
+### ✅ Pros (Lo bueno)
+
+- **Estructura de ventas:** Atacar el problema primero ("Your past the same person over and over...") es una estrategia de marketing muy buena.
+- **Demo técnica:** La sección "Seen in action" (vídeo/demo de la herramienta en local) es lo mejor de su página.
+- **Personalidad:** El detalle del "bigotito" y el uso del favicon de Gentle-AI le dan mucha identidad.
+- **Investigación:** La tabla de comparación de modelos (Performance vs Economy) demuestra que "hizo los deberes".
+- **Comunidad:** Mostrar los contribuidores del proyecto.
+
+### ❌ Contras (A mejorar)
+
+- **Diseño responsive:** La página se rompe en dispositivos móviles y con zoom alto.
+- **Legibilidad:** Falta mucho contraste en los textos.
+- **Efectos visuales:** En la sección "Create your agent", sugirió quitar el movimiento de la cara y dejar solo el efecto de glow para no distraer o molestar.
+- **Jerarquía de modelos:** Ajustar los tamaños de las caras en la selección de modelos (están desiguales).
+
+## 🛠️ Fabri
+
+**Enfoque:** Minimalismo y flujo de instalación.
+
+### ✅ Pros (Lo bueno)
+
+- **Animaciones:** Las micro-interacciones y la forma en la que aparece el contenido al cargar son muy atractivas.
+- **Simplicidad:** La idea de resumir todo a "solo 3 pasos" es excelente para la conversión.
+- **Selector de OS:** Filtrar los comandos por Sistema Operativo (Mac, Linux, Windows con Scoop/PowerShell) es muy útil para el usuario.
+- **Mensaje:** Destacar que solo un paso es manual (init) y el resto es automático.
+
+### ❌ Contras (A mejorar)
+
+- **Tonalidad:** La página es demasiado oscura. Los tonos grises hacen que parezca que los elementos están deshabilitados (disabled).
+- **Wording:** La frase "Plan when it should, execute when it can" suena rara; sugirió cambiarla por algo como "Plan and execute as it should".
+- **UI confusa:** Hay círculos que parecen botones cliqueables pero no hacen nada.
+- **Falta información:** No queda claro que hay que ejecutar el skill-registry y el init para que las herramientas se carguen.
+
+## ⌨️ Irreal
+
+**Enfoque:** Simulación e interactividad fiel al CLI.
+
+### ✅ Pros (Lo bueno)
+
+- **Interactividad:** La simulación del uso con teclado es "espectacular" y lo más destacado de su versión.
+- **Fidelidad:** Es la versión que mejor captura el "lore" y la interfaz real de Gentle-AI.
+- **Funcionalidad:** Incluir la gestión de backups y la configuración de modelos (aunque con correcciones pendientes).
+- **Internacionalización:** Tener la página en español e inglés.
+
+### ❌ Contras (A mejorar)
+
+- **Bugs técnicos:** El ASCII del "beso" en la terminal es un error que hay que eliminar.
+- **Contraste temático:** El tema Kanagawa necesita más rosa o un fondo más oscuro para que resalte realmente.
+- **UX de navegación:** El botón de "Get Started" arriba hace que la gente se salte toda la introducción.
+- **Flujo de backups:** En la gestión de backups, no permite elegir cuál restaurar antes de ejecutar la acción.
+- **Espaciado:** Falta padding para separar la introducción de la sección de utilidad.
+
+## 💡 Recomendaciones generales para la versión unificada
+
+- **Tipografía:** Usar Iosevka (la favorita de The Gentleman) para bloques de código.
+- **Instalación:** Debe estar al principio, no oculta tras mucho scroll.
+- **Contenido olvidado:** Nadie incluyó el comando sync ni la actualización automática; es vital ponerlo.
+- **UX unificada:** Combinar la demo de Gerardo con la interactividad de teclado de Irreal y el selector de OS de Fabri.


### PR DESCRIPTION
Closes #8

## PR type

- [x] Documentation only

## Summary

- Align governance docs with the current review flow
- Add CODEOWNERS so the main collaborators are requested as reviewers
- Clarify that merge policy stays PR-based and owned by the community leads

## Changes

| File | Change |
|------|--------|
| `GOVERNANCE.md` | Document code owner review flow |
| `README.md` | Add code owner review requirement |
| `docs/README.md` | Clarify self-merge policy after required reviews |
| `.github/CODEOWNERS` | Define repository ownership groups |

## Test plan

- [x] Verified docs consistency manually
- [x] Checked GitHub branch protection state

## Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Kept the change scoped
- [x] Used conventional commit format
- [x] No `Co-Authored-By` trailer
