### PR TITLE
docs: close planning loop (ADR accepted + sync gap + feedback synthesis)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -131,7 +131,10 @@ Section order:
 6. **Agents grid** — data-driven from `src/data/agents.ts`.
 7. **Build your own agent** — Gerardo.
 8. **Presets** — Full Gentleman / Ecosystem Only / Minimal / Custom, Becker (unique).
-9. **Install** — five methods: curl, brew, scoop, go install, PowerShell, Fabri.
+9. **Install** — five methods: curl, brew, scoop, go install, PowerShell, Fabri. This section must also document the **post-install lifecycle**, which none of the four reference landings covered:
+   - `sync` — the command that pulls the latest agents, skills, and presets after a successful install.
+   - **Auto-update** — the mechanism that keeps an installed ecosystem current without the user running `sync` manually.
+   - Both belong in `src/data/install.ts` as first-class entries, not as an afterthought in prose.
 10. **Community + Final CTA**.
 11. **Footer**.
 
@@ -208,5 +211,6 @@ After that, Phase 1 starts.
 
 - [`../landing-context.md`](../landing-context.md) — high-level synthesis and merge strategy.
 - [`../landing-strengths.md`](../landing-strengths.md) — per-repo strengths, weaknesses, and ideas to reuse.
+- [`../feedback_gentleman.md`](../feedback_gentleman.md) — per-landing review from the Gentleman, source of the `sync` / auto-update requirement.
 - [`../CONTRIBUTING.md`](../CONTRIBUTING.md) — contribution workflow.
 - [`../GOVERNANCE.md`](../GOVERNANCE.md) — repository governance rules.

--- a/docs/adr/ADR-001-stack.md
+++ b/docs/adr/ADR-001-stack.md
@@ -1,7 +1,8 @@
 # ADR-001 — Base stack for the unified community landing
 
-- **Status**: Proposed
-- **Date**: 2026-04-16
+- **Status**: Accepted
+- **Proposed**: 2026-04-16
+- **Accepted**: 2026-04-19
 - **Deciders**: Community leads (Fabri, Gerardo, IrrealV, Becker)
 - **Supersedes**: —
 - **Superseded by**: —
@@ -27,6 +28,8 @@ The four reference landings provide real evidence — not speculation — about 
 - Gerardo's React-island-heavy approach produced the largest bundle and highest maintenance cost.
 - Becker's Satori-based OG generation is the only build-time image pipeline of the four and has proven sustainable in production.
 - IrrealV's `node --test` smoke suite is the only automated safety net and is lightweight enough to keep.
+
+After this ADR was drafted, the Gentleman delivered a per-landing review (see [`../../feedback_gentleman.md`](../../feedback_gentleman.md)). That review independently confirmed the decisions below — notably the Iosevka mono font, install-at-the-top via the macOS-window widget, route-split bilingualism, and the rejection of a React-island-heavy architecture. No decision in this ADR was revised as a result of the review.
 
 ## Decision
 

--- a/landing-strengths.md
+++ b/landing-strengths.md
@@ -243,6 +243,46 @@ Only some have:
 
 Tailwind version split: Fabri / Gerardo / IrrealV are on v4 with the vite plugin, Becker is still on v3 with the classic integration.
 
+## Gentleman feedback synthesis
+
+After the planning documents were merged, the Gentleman reviewed the four reference landings and produced the feedback captured in [`feedback_gentleman.md`](./feedback_gentleman.md). This section maps that review back to the decisions in [`docs/README.md`](./docs/README.md) so the evidence is traceable.
+
+### Decisions confirmed by the review
+
+| Unified-plan decision | Gentleman signal | Source landing |
+|-----------------------|------------------|----------------|
+| Macos-window install widget in the hero | "Instalación debe estar al principio, no oculta tras mucho scroll" | general |
+| Iosevka mono font | "Usar Iosevka (la favorita de The Gentleman) para bloques de código" | Fabri |
+| OS auto-detection on install tabs | "Selector de OS: filtrar los comandos por Sistema Operativo es muy útil" | Fabri |
+| Problem → Solution narrative | "Atacar el problema primero es una estrategia de marketing muy buena" | Gerardo |
+| Build-time GitHub stats (no hardcoded numbers) | "recomendó que sean datos vivos vía API" | Becker |
+| Keyboard-driven `/demo` as a dedicated page | "La simulación del uso con teclado es espectacular" | IrrealV |
+| Route-split EN/ES i18n | "Tener la página en español e inglés" was a standout of IrrealV's | IrrealV |
+| React islands restricted to `/demo` | "sugirió quitar el movimiento de la cara" (too much motion) and the responsive breakage on Gerardo's React-heavy build | Gerardo |
+| Presets section (Full / Ecosystem / Minimal / Custom) | "La sección donde explica el Core Stack y los componentes ayuda mucho" | Becker |
+
+### New requirements surfaced by the review
+
+| Requirement | Why it was missed | Where it now lives |
+|-------------|-------------------|--------------------|
+| `sync` command | None of the four landings documented it | `docs/README.md` Phase 1 §9 + `src/data/install.ts` |
+| Auto-update flow | Same gap | `docs/README.md` Phase 1 §9 + `src/data/install.ts` |
+| Card alignment discipline (bottom-aligned CTAs) | Only Becker had the issue visibly | Phase 0 design tokens + component conventions |
+| Minimum contrast on body text | Flagged across all four landings | Phase 0 design tokens (palette + WCAG AA target) |
+| Avoid grey-on-grey that reads as `disabled` | Flagged on Fabri | Phase 0 design tokens |
+| No ASCII "kiss" or leftover dev easter eggs | Flagged on IrrealV | `/demo` acceptance criteria |
+
+### Anti-patterns the review made explicit
+
+- **Fake-button circles** (Fabri): decorative elements that look clickable but do nothing. Our tokens must distinguish interactive from decorative at the component level.
+- **Missing install follow-through** (Fabri): hiding the fact that `skill-registry` and `init` are required. The install section must list every step the user actually has to run, in order.
+- **CTA that skips the narrative** (IrrealV "Get Started" at the top): the hero CTA can take the user to install, but it cannot bypass the problem/solution framing for a first-time visitor.
+- **Uneven scaling in visual grids** (Gerardo model faces, Becker Skills): consistent sizing is a design-token concern, not a per-component fix.
+
+This synthesis is the evidence trail future PRs cite when a reviewer asks "where did this requirement come from?". When a new piece of feedback arrives, it is appended here first, then propagated into the relevant ADR or roadmap section.
+
+---
+
 ## How this feeds the community landing
 
 The merge strategy and final architecture live in [`landing-context.md`](./landing-context.md). This document is the evidence trail behind each decision — when somebody asks "why are we using the macOS window widget?", this file is the answer.


### PR DESCRIPTION
## Linked issue

Closes #10

## PR type

- [x] Documentation only

## Summary

- Flip `ADR-001` from `Proposed` to `Accepted` now that PR #7 is on main, and note the Gentleman review confirmed the stack decisions.
- Add the `sync` command and the auto-update flow to Phase 1 §9 (Install). This was flagged as "vital" in `feedback_gentleman.md` and was missing from the roadmap — none of the four reference landings documented it.
- Append a `Gentleman feedback synthesis` section to `landing-strengths.md` that maps the per-landing review onto the unified-plan decisions it confirms or invalidates, plus the new requirements it surfaces.
- Reference `feedback_gentleman.md` in the plan's Related documents so the evidence chain is complete.

No code, no dependencies, no workflows. Pure planning closeout before scaffolding.

## Changes

| File | Change |
|------|--------|
| `docs/adr/ADR-001-stack.md` | Status `Proposed` → `Accepted`; acceptance date `2026-04-19`; Context note on the Gentleman review |
| `docs/README.md` | Phase 1 §9 now lists `sync` and auto-update as first-class install concerns; Related documents references `feedback_gentleman.md` |
| `landing-strengths.md` | New `Gentleman feedback synthesis` section (confirmed decisions, new requirements, anti-patterns) |

## Test plan

- [x] Verified locally (three files, no build involved)
- [x] Checked markdown links to `feedback_gentleman.md` resolve from each document
- [x] Confirmed ADR-001 acceptance date matches today
- [x] Confirmed `sync` / auto-update are now explicit in the roadmap and cross-referenced with `src/data/install.ts` as their implementation home

## Checklist

- [x] Linked an approved issue (#10)
- [x] Added exactly one `type:*` label (`type:docs`)
- [x] Kept the change scoped (docs only, three files)
- [x] Used conventional commit format
- [x] No `Co-Authored-By` trailer

## Out of scope

Scaffolding Astro / Tailwind 4 / TypeScript / pnpm is the **next** issue + PR (Phase 0 foundations). Keeping this PR docs-only makes review fast and keeps the planning artifacts internally consistent before any code lands.