### PR TITLE
fix(footer): resolve section anchors on inner pages

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -14,6 +14,8 @@ const { locale } = Astro.props;
 const dict = t(locale);
 const homeHref = locale === 'en' ? '/' : '/es/';
 
+const resolveFooterHref = (url: string) => (url.startsWith('#') ? `${homeHref}${url}` : url);
+
 const columns = [
   dict.footer.columns.sections,
   dict.footer.columns.community,
@@ -96,7 +98,7 @@ const columns = [
               {column.items.map((item) => (
                 <li>
                   <a
-                    href={item.url}
+                    href={resolveFooterHref(item.url)}
                     class="text-sm text-[var(--color-fg)]/85 transition-colors duration-200 hover:text-[var(--color-primary)]"
                     target={item.url.startsWith('http') ? '_blank' : undefined}
                     rel={item.url.startsWith('http') ? 'noopener noreferrer' : undefined}


### PR DESCRIPTION
## Linked issue

Closes #14

## PR type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Refactor
- [ ] Maintenance / tooling
- [ ] Breaking change

## Summary

- Normalize footer hash-only links so they always point to the localized home page anchors.
- Keep external URLs and non-hash links unchanged.

## Changes

| File | Change |
|------|--------|
| `src/components/Footer.astro` | Resolve hash-only footer links like `#install` into localized home anchors such as `/#install` and `/es/#install` |

## Test plan

- [x] Verified locally
- [ ] Checked visuals if applicable
- [ ] Updated docs if behavior changed

## Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Kept the change scoped
- [x] Used conventional commit format
- [x] No `Co-Authored-By` trailer