### PR TITLE
fix(hero): localize OS auto-detect hint

### DIFF
--- a/src/sections/Hero.astro
+++ b/src/sections/Hero.astro
@@ -175,7 +175,14 @@ const HERO_TABS: HeroTab[] = [
               ))
             }
           </div>
-          <p class="font-mono text-[10px] uppercase tracking-wider text-[var(--color-fg-muted)]" data-hero-os-hint>
+          <p
+            class="font-mono text-[10px] uppercase tracking-wider text-[var(--color-fg-muted)]"
+            data-hero-os-hint
+            data-hint-mac={dict.hero.osHints.mac}
+            data-hint-windows={dict.hero.osHints.windows}
+            data-hint-linux={dict.hero.osHints.linux}
+            data-hint-unknown={dict.hero.osHints.unknown}
+          >
             {dict.hero.osHints.unknown}
           </p>
           {
@@ -251,14 +258,7 @@ const HERO_TABS: HeroTab[] = [
         linux: hint.dataset.hintLinux,
         unknown: hint.dataset.hintUnknown,
       };
-      // Hints come from i18n via aria-label fallback; keep current placeholder text.
-      var hintText = {
-        mac: hint.textContent.includes('Detected') ? hint.textContent : 'Detected ' + 'macOS',
-        windows: 'Detected Windows',
-        linux: 'Detected Linux',
-        unknown: hint.textContent,
-      };
-      hint.textContent = hintText[os] || hint.textContent;
+      hint.textContent = hintMap[os] || hintMap.unknown || hint.textContent;
     }
 
     tabs.forEach(function (tab, idx) {


### PR DESCRIPTION
## Linked issue

Closes #15

## PR type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Refactor
- [ ] Maintenance / tooling
- [ ] Breaking change

## Summary

- Feed the hero install hint from localized i18n values instead of hardcoded English strings.
- Keep the OS auto-detection behavior the same while fixing the Spanish route copy.

## Changes

| File | Change |
|------|--------|
| `src/sections/Hero.astro` | Expose localized OS hint strings as data attributes and use them when the client script updates the active platform hint |

## Test plan

- [x] Verified locally
- [ ] Checked visuals if applicable
- [ ] Updated docs if behavior changed

## Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Kept the change scoped
- [x] Used conventional commit format
- [x] No `Co-Authored-By` trailer